### PR TITLE
Replaced deprecated functions

### DIFF
--- a/nested_inlines/admin.py
+++ b/nested_inlines/admin.py
@@ -130,7 +130,7 @@ class NestedModelAdmin(ModelAdmin):
         return True
     
     @csrf_protect_m
-    @transaction.commit_on_success
+    @transaction.atomic
     def add_view(self, request, form_url='', extra_context=None):
         "The 'add' admin view for this model."
         model = self.model
@@ -225,7 +225,7 @@ class NestedModelAdmin(ModelAdmin):
         return self.render_change_form(request, context, form_url=form_url, add=True)
 
     @csrf_protect_m
-    @transaction.commit_on_success
+    @transaction.atomic
     def change_view(self, request, object_id, form_url='', extra_context=None):
         "The 'change' admin view for this model."
         model = self.model


### PR DESCRIPTION
Replaced "commit_on_success" with "atomic" to avoid warning messages when updating to Django 1.7