### PR TITLE
Fixed browser compatibility

### DIFF
--- a/nested_inlines/static/admin/js/inlines.js
+++ b/nested_inlines/static/admin/js/inlines.js
@@ -32,7 +32,7 @@
 
 		if (isAddButtonVisible(options)) {
 			var addButton;
-			if ($this.attr("tagName") == "TR") {
+			if ($this.attr("tagName") == "TR" || $this.prop("tagName") == "TR") {
 				// If forms are laid out as table rows, insert the
 				// "add" button in a new table row:
 				var numCols = this.eq(-1).children().length;


### PR DESCRIPTION
Chrome doesn't recognize $this.prop("tagName") ,
for this reason I check with $this.attr("tagName") too, when check if form are laid out as  table row